### PR TITLE
chore(naming): rename project from distroless to atoma

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -6,10 +6,10 @@
 ---
 repository:
   # See https://docs.github.com/en/rest/reference/repos#update-a-repository for all available settings.
-  name: distroless
+  name: atoma
   description: Lightweight and secure container images
-  homepage: https://github.com/nlamirault/distroless
-  topics: distroless, wolfi, apk, melange
+  homepage: https://github.com/nlamirault/atoma
+  topics: atoma, wolfi, apk, melange
   private: false
   has_issues: true
   has_projects: true

--- a/.github/workflows/infra-tools-release.yaml
+++ b/.github/workflows/infra-tools-release.yaml
@@ -26,7 +26,7 @@ jobs:
     name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
     uses: "./.github/workflows/release.yaml"
     with:
-      repository: nlamirault/distroless/infra-tools
+      repository: nlamirault/atoma/infra-tools
       config-dir: images/infra-tools
       tag: ${{ github.ref_name }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
       target: ${{ matrix.variant }}

--- a/.github/workflows/infra-tools.yaml
+++ b/.github/workflows/infra-tools.yaml
@@ -38,7 +38,7 @@ jobs:
     name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
     uses: "./.github/workflows/release.yaml"
     with:
-      repository: nlamirault/distroless/infra-tools
+      repository: nlamirault/atoma/infra-tools
       config-dir: images/infra-tools
       tag: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
       target: ${{ matrix.variant }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ on: # yamllint disable-line rule:truthy
         description: "Image repository"
         type: string
         required: false
-        # default: nlamirault/distroless/${{ github.workflow }}
+        # default: nlamirault/atoma/${{ github.workflow }}
       tag:
         description: "Image tag"
         type: string

--- a/.github/workflows/shell-release.yaml
+++ b/.github/workflows/shell-release.yaml
@@ -26,7 +26,7 @@ jobs:
     name: ${{ matrix.version }}${{ matrix.variant == 'dev' && '-dev' || '' }}
     uses: "./.github/workflows/release.yaml"
     with:
-      repository: nlamirault/distroless/shell
+      repository: nlamirault/atoma/shell
       config-dir: images/shell
       tag: ${{ github.ref_name }}${{ matrix.variant == 'dev' && '-dev' || '' }}
       target: ${{ matrix.variant }}

--- a/.github/workflows/shell.yaml
+++ b/.github/workflows/shell.yaml
@@ -38,7 +38,7 @@ jobs:
     name: ${{ matrix.version }}${{ matrix.variant == 'dev' && '-dev' || '' }}
     uses: "./.github/workflows/release.yaml"
     with:
-      repository: nlamirault/distroless/shell
+      repository: nlamirault/atoma/shell
       config-dir: images/shell
       tag: ${{ matrix.version }}${{ matrix.variant == 'dev' && '-dev' || '' }}
       target: ${{ matrix.variant }}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ authors:
     email: nicolas.lamirault@gmail.com
 identifiers:
   - type: url
-    value: 'https://github.com/nlamirault/distroless'
+    value: 'https://github.com/nlamirault/atoma'
     description: URL to the GitHub repository for ai-rules
-repository-code: 'https://github.com/nlamirault/distroless'
-url: 'https://github.com/nlamirault/distroless'
+repository-code: 'https://github.com/nlamirault/atoma'
+url: 'https://github.com/nlamirault/atoma'
 license: Apache-2.0

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean: ## Cleanup
 	@find . -name "melange.rsa*" | xargs rm -f
 	@find . -name "packages" | xargs rm -fr
 	@rm -f sbom-*.cdx sbom-*.json
-	@rm -f portefaix-distroless.tar
+	@rm -f portefaix-atoma.tar
 
 .PHONY: check
 check: check-docker ## Check requirements

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Distroless
+# Atoma
 
 A set of **lightweight and secure** container images based on the
 [Wolfi](https://wolfi.dev/) Linux distribution.
@@ -7,8 +7,8 @@ A set of **lightweight and secure** container images based on the
 
 | Image Name                           | Pull                                                    |
 | ------------------------------------ | ------------------------------------------------------- |
-| [shell](./images/shell/)             | `docker pull ghcr.io/nlamirault/distroless/shell`       |
-| [infra-tools](./images/infra-tools/) | `docker pull ghcr.io/nlamirault/distroless/infra-tools` |
+| [shell](./images/shell/)             | `docker pull ghcr.io/nlamirault/atoma/shell`       |
+| [infra-tools](./images/infra-tools/) | `docker pull ghcr.io/nlamirault/atoma/infra-tools` |
 
 ## Contributing
 

--- a/docs/adr/001-wolfi-for-atoma-images.md
+++ b/docs/adr/001-wolfi-for-atoma-images.md
@@ -8,7 +8,7 @@ informed: Development team
 spdx-license: Apache-2.0
 ---
 
-# ADR-001: Distroless Container Images
+# ADR-001: Atoma Container Images
 
 ## Context
 

--- a/hack/commons.mk
+++ b/hack/commons.mk
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-APP = distroless
+APP = atoma
 
-BANNER = D I S T R O L E S S
+BANNER = A T O M A
 
 CONFIG_HOME = $(or ${XDG_CONFIG_HOME},${XDG_CONFIG_HOME},${HOME}/.config)
 

--- a/images/apko.yaml
+++ b/images/apko.yaml
@@ -26,8 +26,8 @@ archs:
 
 annotations:
   org.opencontainers.image.authors: "Nicolas Lamirault <nicolas.lamirault@gmail.com>"
-  org.opencontainers.image.documentation: "https://github.com/nlamirault/distroless"
-  org.opencontainers.image.issue-tracker: "https://github.com/nlamirault/distroless/issues"
-  org.opencontainers.image.licenses: "Apache-2.0"
-  org.opencontainers.image.source: "https://github.com/nlamirault/distroless"
+  org.opencontainers.image.documentation: \"https://github.com/nlamirault/atoma\"
+  org.opencontainers.image.issue-tracker: \"https://github.com/nlamirault/atoma/issues\"
+  org.opencontainers.image.licenses: \"Apache-2.0\"
+  org.opencontainers.image.source: \"https://github.com/nlamirault/atoma\"
   org.opencontainers.image.vendor: "Nicolas Lamirault"

--- a/images/infra-tools/README.md
+++ b/images/infra-tools/README.md
@@ -24,9 +24,9 @@ operations.
 
 | 📌 Version   | ⬇️ Pull URL                                             |
 | ------------ | ------------------------------------------------------ |
-| latest       | ghcr.io/nlamirault/distroless/infra-tools:latest       |
-| latest-shell | ghcr.io/nlamirault/distroless/infra-tools:latest-shell |
-| latest-dev   | ghcr.io/nlamirault/distroless/infra-tools:latest-dev   |
+| latest       | ghcr.io/nlamirault/atoma/infra-tools:latest       |
+| latest-shell | ghcr.io/nlamirault/atoma/infra-tools:latest-shell |
+| latest-dev   | ghcr.io/nlamirault/atoma/infra-tools:latest-dev   |
 
 ## ✅ Verify the Build Provenance
 
@@ -41,7 +41,7 @@ the image:
 ```shell
 gh attestation verify \
   --owner nlamirault \
-  oci://ghcr.io/nlamirault/distroless/infra-tools:latest
+  oci://ghcr.io/nlamirault/atoma/infra-tools:latest
 ```
 
 - **Shell image**
@@ -49,7 +49,7 @@ gh attestation verify \
 ```shell
 gh attestation verify \
   --owner nlamirault \
-  oci://ghcr.io/nlamirault/distroless/infra-tools:latest-shell
+  oci://ghcr.io/nlamirault/atoma/infra-tools:latest-shell
 ```
 
 - **Dev image**
@@ -57,7 +57,7 @@ gh attestation verify \
 ```shell
 gh attestation verify \
   --owner nlamirault \
-  oci://ghcr.io/nlamirault/distroless/infra-tools:latest-dev
+  oci://ghcr.io/nlamirault/atoma/infra-tools:latest-dev
 ```
 
 ### Using Cosign
@@ -69,7 +69,7 @@ cosign verify-attestation \
  --type slsaprovenance \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  --certificate-identity-regexp '^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
- ghcr.io/nlamirault/distroless/infra-tools:latest@sha256:xxxxxx
+ ghcr.io/nlamirault/atoma/infra-tools:latest@sha256:xxxxxx
 ```
 
 - **Shell image**
@@ -79,7 +79,7 @@ cosign verify-attestation \
   --type slsaprovenance \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp '^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
-  ghcr.io/nlamirault/distroless/infra-tools:latest-shell@sha256:xxxxx
+  ghcr.io/nlamirault/atoma/infra-tools:latest-shell@sha256:xxxxx
 ```
 
 - **Dev image**
@@ -89,7 +89,7 @@ cosign verify-attestation \
   --type slsaprovenance \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp '^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
-  ghcr.io/nlamirault/distroless/infra-tools:latest-dev@sha256:xxxxxx
+  ghcr.io/nlamirault/atoma/infra-tools:latest-dev@sha256:xxxxxx
 ```
 
 ## ✅ Verify the Image Signature
@@ -105,8 +105,8 @@ following command:
 ```shell
 cosign verify \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-  --certificate-identity=https://github.com/nlamirault/distroless/.github/workflows/infra-tools.yaml@refs/heads/main \
-  ghcr.io/nlamirault/distroless/infra-tools:latest | jq
+  --certificate-identity=https://github.com/nlamirault/atoma/.github/workflows/infra-tools.yaml@refs/heads/main \
+  ghcr.io/nlamirault/atoma/infra-tools:latest | jq
 ```
 
 - **Shell image**
@@ -114,8 +114,8 @@ cosign verify \
 ```shell
 cosign verify \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-  --certificate-identity=https://github.com/nlamirault/distroless/.github/workflows/release.yaml@refs/heads/main \
-  ghcr.io/nlamirault/distroless/infra-tools:latest-shell | jq
+  --certificate-identity=https://github.com/nlamirault/atoma/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/nlamirault/atoma/infra-tools:latest-shell | jq
 ```
 
 - **Dev image**
@@ -123,8 +123,8 @@ cosign verify \
 ```shell
 cosign verify \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-  --certificate-identity=https://github.com/nlamirault/distroless/.github/workflows/release.yaml@refs/heads/main \
-  ghcr.io/nlamirault/distroless/infra-tools:latest-dev | jq
+  --certificate-identity=https://github.com/nlamirault/atoma/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/nlamirault/atoma/infra-tools:latest-dev | jq
 ```
 
 ## ✅ Verify the Image Attestations
@@ -139,8 +139,8 @@ directly from the container registry and can be verified using using
 cosign verify-attestation \
   --type=https://spdx.dev/Document \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-  --certificate-identity=https://github.com/nlamirault/distroless/.github/workflows/release.yaml@refs/heads/main \
-  ghcr.io/nlamirault/distroless/infra-tools:latest
+  --certificate-identity=https://github.com/nlamirault/atoma/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/nlamirault/atoma/infra-tools:latest
 ```
 
 - **Shell image**
@@ -149,8 +149,8 @@ cosign verify-attestation \
 cosign verify-attestation \
   --type=https://spdx.dev/Document \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-  --certificate-identity=https://github.com/nlamirault/distroless/.github/workflows/release.yaml@refs/heads/main \
-  ghcr.io/nlamirault/distroless/infra-tools:latest-shell
+  --certificate-identity=https://github.com/nlamirault/atoma/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/nlamirault/atoma/infra-tools:latest-shell
 ```
 
 This will pull in the signature for the attestation specified by the --type
@@ -169,7 +169,7 @@ following command will obtain the SBOM for the python image on `linux/amd64`:
 cosign download attestation \
   --platform=linux/amd64 \
   --predicate-type=https://spdx.dev/Document \
-  ghcr.io/nlamirault/distroless/infra-tools:latest | jq -r .payload | base64 -d | jq .predicate
+  ghcr.io/nlamirault/atoma/infra-tools:latest | jq -r .payload | base64 -d | jq .predicate
 ```
 
 - **Shell image**
@@ -178,5 +178,5 @@ cosign download attestation \
 cosign download attestation \
   --platform=linux/amd64 \
   --predicate-type=https://spdx.dev/Document \
-  ghcr.io/nlamirault/distroless/infra-tools:latest-shell | jq -r .payload | base64 -d | jq .predicate
+  ghcr.io/nlamirault/atoma/infra-tools:latest-shell | jq -r .payload | base64 -d | jq .predicate
 ```

--- a/images/infra-tools/prod.yaml
+++ b/images/infra-tools/prod.yaml
@@ -38,4 +38,4 @@ cmd: /usr/bin/sh -l
 annotations:
   org.opencontainers.image.title: "infra-tools"
   org.opencontainers.image.description: "infra-tools image based on Wolfi OS"
-  org.opencontainers.image.source: "https://github.com/nlamirault/distroless/tree/main/images/infra-tools"
+  org.opencontainers.image.source: "https://github.com/nlamirault/atoma/tree/main/images/infra-tools"

--- a/images/shell/README.md
+++ b/images/shell/README.md
@@ -6,8 +6,8 @@ Container image with Bash and tooling including `curl`, `netcat`, `jq`, `yq`.
 
 | 📌 Version | ⬇️ Pull URL                                     |
 | ---------- | ---------------------------------------------- |
-| latest     | ghcr.io/nlamirault/distroless/shell:latest     |
-| latest-dev | ghcr.io/nlamirault/distroless/shell:latest-dev |
+| latest     | ghcr.io/nlamirault/atoma/shell:latest     |
+| latest-dev | ghcr.io/nlamirault/atoma/shell:latest-dev |
 
 ## ✅ Verify the Provenance
 
@@ -20,7 +20,7 @@ the image:
 ```shell
 gh attestation verify \
   --owner nlamirault \
-  oci://ghcr.io/nlamirault/distroless/shell:latest
+  oci://ghcr.io/nlamirault/atoma/shell:latest
 ```
 
 - **Shell image**
@@ -28,5 +28,5 @@ gh attestation verify \
 ```shell
 gh attestation verify \
   --owner nlamirault \
-  oci://ghcr.io/nlamirault/distroless/shell:latest-shell
+  oci://ghcr.io/nlamirault/atoma/shell:latest-shell
 ```

--- a/images/shell/prod.yaml
+++ b/images/shell/prod.yaml
@@ -24,4 +24,4 @@ entrypoint:
 annotations:
   org.opencontainers.image.title: "shell"
   org.opencontainers.image.description: "Shell image based on Wolfi OS"
-  org.opencontainers.image.source": "https://github.com/nlamirault/distroless/tree/main/images/shell"
+  org.opencontainers.image.source": "https://github.com/nlamirault/atoma/tree/main/images/shell"


### PR DESCRIPTION
## Summary

- Rename project references from 'distroless' to 'atoma'
- Update GitHub Actions, settings, Makefile, and apko files
- Rename architecture decision record to match the new project name