### PR TITLE
docs(docs): add comprehensive documentation following Diátaxis framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@
 A set of **lightweight and secure** container images based on the
 [Wolfi](https://wolfi.dev/) Linux distribution.
 
+## Documentation
+
+Documentation follows the [Diátaxis](https://diataxis.fr/) framework — see [`docs/`](docs/) for the full index.
+
+| Type              | Documents                                                                                          |
+| ----------------- | -------------------------------------------------------------------------------------------------- |
+| **Tutorials**     | [Getting started](docs/tutorials/getting-started.md)                                               |
+| **How-to guides** | [Build and test images](docs/how-to/howto-build.md) · [Verify images](docs/how-to/howto-verify.md) |
+| **Reference**     | [Configuration](docs/reference/configuration.md) · [Makefile commands](docs/reference/makefile.md) |
+| **Explanation**   | [Architecture and design](docs/explanation/architecture.md)                                        |
+
 ## Available Images
 
 | Image Name                           | Pull                                                    |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,47 @@
+# Atoma Documentation
+
+**Atoma** is a set of lightweight and secure container images based on the [Wolfi](https://wolfi.dev/) Linux distribution. It uses [apko](https://github.com/chainguard-dev/apko) and [melange](https://github.com/chainguard-dev/melange) to build minimal, distroless images that reduce security attack surfaces.
+
+This documentation is organized into four sections according to the [Diátaxis](https://diataxis.fr/) framework to match different user needs.
+
+---
+
+## Tutorials — learning by doing
+
+Start here if you are new to Atoma and want to build your first container image.
+
+| Document | Description |
+| --- | --- |
+| [Getting started](tutorials/getting-started.md) | Set up tools and build your first container image locally |
+
+---
+
+## How-to guides — solving specific problems
+
+Use these guides to perform common development and operations tasks.
+
+| Document | Description |
+| --- | --- |
+| [Build and test images](how-to/howto-build.md) | How to build dev/prod profiles and test or scan local images |
+| [Verify images](how-to/howto-verify.md) | How to verify build provenance, signatures, and SBOMs using `cosign` and `gh` |
+
+---
+
+## Reference — technical specifications
+
+Consult these for detailed lists, configuration options, and command options.
+
+| Document | Description |
+| --- | --- |
+| [Configuration](reference/configuration.md) | Schema structure for `apko` and `melange` configurations |
+| [Makefile commands](reference/makefile.md) | List of make targets for building, scanning, and cleaning images |
+
+---
+
+## Explanation — understanding the design
+
+Read these to understand the architectural principles, choices, and concepts behind Atoma.
+
+| Document | Description |
+| --- | --- |
+| [Architecture and design](explanation/architecture.md) | Why Wolfi and apko/melange? How distroless enhances supply-chain security |

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,0 +1,61 @@
+# Architecture and design
+
+This section explains the design principles behind the Atoma image ecosystem and the reasoning behind choosing **Wolfi**, **apko**, and **melange**.
+
+---
+
+## 1. What is a "Distroless" container image?
+
+Standard container base images (like Ubuntu, Debian, or Alpine) packages a full Linux operating system, including package managers, shells, utility commands, and extensive system libraries. While convenient, this comes with major security and operational tradeoffs:
+
+1. **Large attack surface**: Extraneous packages can contain critical vulnerabilities (CVEs) that are exposed inside your container network.
+2. **Larger image size**: Unused packages waste disk space, network bandwidth, and memory.
+
+**Distroless** container images solve this by containing *only* your application and its direct runtime dependencies (such as libc, ca-certificates, and libraries). They exclude shells, package managers, and other standard OS tools.
+
+---
+
+## 2. Why Wolfi OS?
+
+[Wolfi](https://wolfi.dev/) is an open-source Linux distribution specifically designed for modern cloud-native workloads, container security, and securing the software supply chain:
+
+- **Security-first**: Package updates are quickly compiled and released to resolve CVEs promptly.
+- **Glibc compatibility**: Unlike Alpine (which uses `musl` libc), Wolfi uses `glibc` (GNU C Library). This ensures compatibility with most compiled programs and languages (Go, Node.js, Python, Java) without compilation errors.
+- **Granular packages**: Packages are split into minimal units, making it easy to include only what is needed.
+
+---
+
+## 3. The tooling: Apko & Melange
+
+To build Wolfi-based distroless images, Atoma uses two companion tools designed by Chainguard:
+
+### Melange: Package building
+`melange` builds APK packages from source inside a clean, reproducible, and secure environment. It outputs standard `.apk` packages that can be signed and distributed. We use `melange` to compile dependencies (like `jsonnet-bundler` in `infra-tools`) that are not present in upstream repositories.
+
+### Apko: Image assembly
+`apko` acts as the assembler. Unlike a `Dockerfile` which executes imperative commands (like `apt install` or `apk add` inside a running layer), `apko` builds the container image filesystem *declaratively*:
+- It reads a YAML list of APK package dependencies.
+- It pulls them, unpacks their contents directly into a directory structure, and produces an OCI image layer.
+- It generates reproducible builds (building the exact same configuration yields the identical cryptographic image digest).
+- It generates rich metadata (SBOMs, signatures) directly during the build step.
+
+---
+
+## 4. Defaulting to Non-Root
+
+Running containers as root is a high-risk practice. If an attacker escapes a root-run container, they may gain administrator rights on the host node.
+
+Atoma images enforce non-root security by default:
+- An unprivileged user `nonroot` (UID `65532`, GID `65532`) is created.
+- The `apko` configuration sets `run-as: nonroot` as the default execution identity.
+- The default working directory is set to `/home/nonroot`.
+
+---
+
+## 5. Software Supply Chain Security
+
+Securing the supply chain means verifying who built the image and ensuring that its contents have not been modified. Atoma addresses this through:
+
+1. **Cryptographic signatures**: All releases are signed via Sigstore Cosign.
+2. **Build provenance**: Build workflows generate SLSA (Supply-chain Levels for Software Artifacts) provenance attestations.
+3. **Software Bill of Materials (SBOM)**: Every image contains a verified record of its component packages, allowing instant auditing.

--- a/docs/how-to/howto-build.md
+++ b/docs/how-to/howto-build.md
@@ -1,0 +1,83 @@
+# How to build and test images
+
+This guide outlines how to build different image profiles (production, development, shell), generate Software Bill of Materials (SBOMs), scan for vulnerabilities, and package custom APKs using melange.
+
+## Build profiles
+
+Atoma supports three primary build profiles for images, defined by YAML configurations:
+
+| Profile | Config File | Make Command | Purpose |
+| --- | --- | --- | --- |
+| **Production** | `prod.yaml` | `make build-image IMAGE=...` | Minimal container image optimized for security and size. |
+| **Development** | `dev.yaml` | `make build-dev-image IMAGE=...` | Includes debugging tools, shells, and extra packages. |
+| **Shell** | `shell.yaml` | `make build-shell-image IMAGE=...` | Alternative profile tailored with shell environments. |
+
+### Build all profiles at once
+
+To build production, development, and shell profiles in one command:
+
+```bash
+make build-all IMAGE=images/infra-tools
+```
+
+---
+
+## Building custom APK packages with melange
+
+When an image directory includes a `melange.yaml` file (such as in `images/infra-tools`), a custom APK package must be built before compiling the image.
+
+The build process is automated:
+1. `make build-image` detects `melange.yaml`.
+2. It executes `melange keygen` if no key exists in `${PWD}/keys/melange.rsa`.
+3. It builds the package in a local directory using the `cgr.dev/chainguard/melange` container.
+4. `apko` consumes the package from the local packages repository `--build-repository-append /work/packages`.
+
+To manually trigger only the APK build:
+
+```bash
+make build-apk IMAGE=images/infra-tools
+```
+
+---
+
+## Test and inspect images
+
+Once an image has been compiled into a `.tar` archive under its subdirectory (e.g., `images/shell/shell.tar`), you can run the following targets:
+
+### Run basic verification tests
+
+```bash
+make test IMAGE=images/shell
+```
+
+This loads the tarball into Docker and runs `--version` tests to ensure the binaries work.
+
+### Scan images for vulnerabilities
+
+Atoma uses [Grype](https://github.com/anchore/grype) to check images for security vulnerabilities:
+
+```bash
+make scan IMAGE=images/infra-tools
+```
+
+### Generate SBOMs (Software Bill of Materials)
+
+Atoma uses [Syft](https://github.com/anchore/syft) to produce comprehensive SBOMs in both SPDX and CycloneDX formats:
+
+```bash
+make sbom IMAGE=images/infra-tools
+```
+
+This creates two files in your current working directory:
+- `sbom-<image-name>.json` (SPDX format)
+- `sbom-<image-name>.cdx` (CycloneDX format)
+
+---
+
+## Cleaning build artifacts
+
+To clean up all local build cache, tarballs, generated keys, SBOMs, and local packages, run:
+
+```bash
+make clean
+```

--- a/docs/how-to/howto-verify.md
+++ b/docs/how-to/howto-verify.md
@@ -1,0 +1,59 @@
+# How to verify image signatures and provenance
+
+To ensure container images have not been tampered with and were built by the correct CI/CD pipelines, Atoma cryptographically signs its releases and generates build attestations using [Sigstore Cosign](https://www.sigstore.dev/) and GitHub's build provenance system.
+
+Choose the verification method below based on your available tools.
+
+## 1. Verify build provenance using GitHub CLI
+
+The GitHub CLI (`gh`) can check the build provenance, detailing the exact repository, commit, workflow, and runner that generated the image.
+
+Run the following command (substituting `shell` or `infra-tools` and the target tag):
+
+```shell
+gh attestation verify \
+  --owner nlamirault \
+  oci://ghcr.io/nlamirault/atoma/shell:latest
+```
+
+---
+
+## 2. Verify signatures using Cosign
+
+All official Atoma images are cryptographically signed during the release pipeline. You can verify the signature validity and the identity of the signer:
+
+```shell
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/nlamirault/atoma/.github/workflows/infra-tools.yaml@refs/heads/main \
+  ghcr.io/nlamirault/atoma/infra-tools:latest | jq
+```
+
+*Note: Replace the `--certificate-identity` value with the workflow path of the specific image you are verifying (e.g. `shell.yaml` or `release.yaml` depending on the pipeline).*
+
+---
+
+## 3. Verify SBOM attestations
+
+To verify that the SPDX SBOM attestation associated with the image is authentic and signed by our workflow:
+
+```shell
+cosign verify-attestation \
+  --type=https://spdx.dev/Document \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity=https://github.com/nlamirault/atoma/.github/workflows/release.yaml@refs/heads/main \
+  ghcr.io/nlamirault/atoma/infra-tools:latest
+```
+
+---
+
+## 4. Download and inspect SBOM attestations
+
+If you want to pull the verified SBOM directly from the registry for auditing purposes:
+
+```shell
+cosign download attestation \
+  --platform=linux/amd64 \
+  --predicate-type=https://spdx.dev/Document \
+  ghcr.io/nlamirault/atoma/infra-tools:latest | jq -r .payload | base64 -d | jq .predicate
+```

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,95 @@
+# Configuration schema reference
+
+Atoma uses two key configuration definitions to construct its secure base images: **apko** for image assembly and **melange** for package building.
+
+## Apko configuration schema
+
+An `apko` configuration (e.g. `prod.yaml`, `dev.yaml`) describes the target environment, package registry repos, security credentials, user accounts, target architectures, and standard metadata.
+
+### Example block
+
+```yaml
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - bash
+    - curl
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: nonroot
+
+work-dir: /home/nonroot
+
+archs:
+  - amd64
+  - arm64
+
+annotations:
+  org.opencontainers.image.authors: "Nicolas Lamirault <nicolas.lamirault@gmail.com>"
+```
+
+### Parameter description
+
+- `contents.keyring`: List of URLs to public keys used to verify APK packages.
+- `contents.repositories`: Repositories list from where APK packages are downloaded (e.g. Wolfi OS repository).
+- `contents.packages`: List of packages to install in the container image.
+- `accounts`: Configures user ID (UID) and group ID (GID) mappings.
+  - `run-as`: Specifies the default user context executing inside the container (defaults to `nonroot` for security).
+- `work-dir`: The default working directory for the runtime container.
+- `archs`: List of CPU architectures to compile for (multi-arch output).
+- `annotations`: Open Container Initiative (OCI) metadata mapping.
+
+---
+
+## Melange configuration schema
+
+A `melange.yaml` file defines how to build an APK package from source code or binaries (useful when Wolfi does not package a dependency natively).
+
+### Example structure
+
+```yaml
+package:
+  name: jsonnet-bundler
+  version: 0.6.0
+  epoch: 0
+  description: "Jsonnet package manager"
+  target-architecture:
+    - all
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/jsonnet-bundler/jsonnet-bundler
+      tag: v0.6.0
+  - runs: |
+      make jsonnet-bundler
+  - uses: strip
+```
+
+### Parameter description
+
+- `package`: Standard metadata for the generated APK package (name, version, epoch, description, license).
+- `environment`: The build-time dependencies needed to compile the package (e.g., compilers like `go`, `rust`, or utilities like `git`).
+- `pipeline`: A sequence of steps (actions or shell scripts) executed in a clean environment to check out source code, compile the program, and package target binaries.

--- a/docs/reference/makefile.md
+++ b/docs/reference/makefile.md
@@ -1,0 +1,18 @@
+# Makefile commands reference
+
+This reference guide documents all commands exposed by the root [Makefile](../../Makefile) of the project.
+
+Every command that requires an image name expects the environment variable `IMAGE` to point to the image subdirectory (for example, `IMAGE=images/shell` or `IMAGE=images/infra-tools`).
+
+| Command | Description |
+| --- | --- |
+| `make clean` | Removes local build files, generated RSA keys, local package caches (`packages/`), tarballs, and SBOMs. |
+| `make check` | Validates that requirements (such as Docker daemon availability) are satisfied. |
+| `make build-apk` | Builds custom APK packages using Docker and `melange` if a `melange.yaml` exists in the target image path. |
+| `make build-image` | Builds a production-ready container image (`prod.yaml`) using `apko`. Triggers APK builds first if required. |
+| `make build-dev-image` | Builds a development container image (`dev.yaml`) using `apko`. |
+| `make build-shell-image` | Builds a shell container image (`shell.yaml`) using `apko`. |
+| `make build-all` | Compiles the custom APK, then builds the production, development, and shell container images consecutively. |
+| `make test` | Loads the compiled `.tar` image archive into your local Docker daemon and runs execution health-checks. |
+| `make scan` | Inspects the compiled container image using `grype` to discover any software vulnerabilities (CVEs). |
+| `make sbom` | Generates a Software Bill of Materials (SBOM) in SPDX and CycloneDX formats using `syft`. |

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,0 +1,64 @@
+# Getting started with Atoma
+
+This tutorial will guide you through setting up your environment and building your first lightweight container image using Atoma's build system. We will build the `shell` image, which provides a secure base environment with common tools.
+
+## Prerequisites
+
+Before starting, ensure you have the following installed on your host machine:
+
+- **Docker** (or another container runtime supported by apko)
+- **Make**
+- **Git**
+
+## Step 1: Clone the repository
+
+First, clone the Atoma repository and navigate to its root directory:
+
+```bash
+git clone https://github.com/nlamirault/atoma.git
+cd atoma
+```
+
+## Step 2: Clean and prepare the build environment
+
+Before starting, clean up any previous build outputs:
+
+```bash
+make clean
+```
+
+This removes any pre-existing TAR archives, SBOM JSON files, or local keys to ensure a clean build.
+
+## Step 3: Build the Shell container image
+
+We will use the Makefile to trigger an `apko` build inside a Docker container. Run the following command to build the production profile of the `shell` image:
+
+```bash
+make build-image IMAGE=images/shell
+```
+
+**What is happening?**
+1. Since `images/shell` only has `apko` configs (`prod.yaml` / `dev.yaml`), `apko` is executed inside a docker container.
+2. It fetches Wolfi packages defined in the configuration, resolves dependencies, and packs them into a root filesystem.
+3. It outputs a tarball containing the container image at `images/shell/shell.tar`.
+
+## Step 4: Load and test the image
+
+Once built, verify the image by running the test suite target. The test suite loads the image tarball into your local Docker daemon and runs a basic sanity check:
+
+```bash
+make test IMAGE=images/shell
+```
+
+Expected output should indicate that the image loaded successfully and can execute basic command checks:
+
+```text
+[atoma] Test container image
+Loaded image: shell:latest
+```
+
+## Next steps
+
+- Learn more about the building workflows in [Build and test images](../how-to/howto-build.md).
+- Understand how configurations are defined in [Configuration reference](../reference/configuration.md).
+- Dive deep into how apko and Wolfi work together in [Architecture and design](../explanation/architecture.md).


### PR DESCRIPTION
## Summary

- Adds a complete documentation structure organized by the Diátaxis framework
- Includes tutorials for getting started with Atoma
- Adds how-to guides for building and verifying images
- Provides reference documentation for configurations and Makefile commands
- Documents architecture and design principles
- Updates README with a documentation index table linking to all four Diátaxis categories
