### PR TITLE
feat(vex): add openvex vex support to ci scan and validation workflows

### DIFF
--- a/.github/workflows/infra-tools-release.yaml
+++ b/.github/workflows/infra-tools-release.yaml
@@ -30,4 +30,5 @@ jobs:
       config-dir: images/infra-tools
       tag: ${{ github.ref_name }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
       target: ${{ matrix.variant }}
+      vex-file: vex/infra-tools.openvex.json
     secrets: inherit

--- a/.github/workflows/infra-tools.yaml
+++ b/.github/workflows/infra-tools.yaml
@@ -42,4 +42,5 @@ jobs:
       config-dir: images/infra-tools
       tag: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
       target: ${{ matrix.variant }}
+      vex-file: vex/infra-tools.openvex.json
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -301,7 +301,7 @@ jobs:
           vex_doc="merged.openvex.json"
           echo "Using merged VEX document"
         fi
-        vexctl filter "${raw_sarif}" --vex "${vex_doc}" > "${filtered_sarif}"
+        vexctl filter "${raw_sarif}" "${vex_doc}" > "${filtered_sarif}"
         raw_count=$(jq '[.runs[].results // [] | length] | add // 0' "${raw_sarif}")
         filtered_count=$(jq '[.runs[].results // [] | length] | add // 0' "${filtered_sarif}")
         suppressed=$((raw_count - filtered_count))

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,11 @@ on: # yamllint disable-line rule:truthy
         type: string
         required: false
         default: "true"
+      vex-file:
+        description: "Path to the image-specific OpenVEX document (e.g. vex/infra-tools.openvex.json)"
+        type: string
+        required: false
+        default: ""
 
 env:
   REGISTRY: ghcr.io
@@ -250,6 +255,9 @@ jobs:
     - name: 🚚 Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+    - name: 🎉 Setup vexctl
+      uses: openvex/setup-vexctl@v0.1.0
+
     - name: ✅ Scan image
       id: scan
       uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
@@ -260,7 +268,55 @@ jobs:
         severity-cutoff: "high"
         output-format: "sarif"
 
-    - name: ⬆️ Upload SARIF
+    - name: 🔀 Merge all VEX documents
+      id: vex-merge
+      shell: bash
+      run: |
+        shopt -s nullglob
+        vex_files=(vex/*.openvex.json)
+        shopt -u nullglob
+        if [ "${#vex_files[@]}" -eq 0 ]; then
+          echo "skip=true" >> $GITHUB_OUTPUT
+          echo "No VEX files found — skipping merge"
+          exit 0
+        fi
+        echo "skip=false" >> $GITHUB_OUTPUT
+        echo "Merging ${#vex_files[@]} VEX file(s): ${vex_files[*]}"
+        vexctl merge "${vex_files[@]}" > merged.openvex.json
+        echo "merged.openvex.json contents:"
+        cat merged.openvex.json
+
+    - name: 🔒 Filter SARIF with VEX
+      id: vex-filter
+      if: steps.vex-merge.outputs.skip == 'false'
+      shell: bash
+      run: |
+        raw_sarif="${{ steps.scan.outputs.sarif }}"
+        filtered_sarif="filtered.sarif"
+        # Prefer the image-specific VEX file when provided; fall back to merged.
+        if [ -n "${{ inputs.vex-file }}" ] && [ -f "${{ inputs.vex-file }}" ]; then
+          vex_doc="${{ inputs.vex-file }}"
+          echo "Using image-specific VEX: ${vex_doc}"
+        else
+          vex_doc="merged.openvex.json"
+          echo "Using merged VEX document"
+        fi
+        vexctl filter "${raw_sarif}" --vex "${vex_doc}" > "${filtered_sarif}"
+        raw_count=$(jq '[.runs[].results // [] | length] | add // 0' "${raw_sarif}")
+        filtered_count=$(jq '[.runs[].results // [] | length] | add // 0' "${filtered_sarif}")
+        suppressed=$((raw_count - filtered_count))
+        echo "Raw findings: ${raw_count} | After VEX filter: ${filtered_count} | Suppressed: ${suppressed}"
+        echo "sarif=${filtered_sarif}" >> $GITHUB_OUTPUT
+
+    - name: ⬆️ Upload SARIF (VEX-filtered)
+      if: steps.vex-merge.outputs.skip == 'false'
+      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      with:
+        sarif_file: ${{ steps.vex-filter.outputs.sarif }}
+        category: ${{ github.workflow }}
+
+    - name: ⬆️ Upload SARIF (raw — no VEX files found)
+      if: steps.vex-merge.outputs.skip == 'true'
       uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         sarif_file: ${{ steps.scan.outputs.sarif }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,7 +180,7 @@ jobs:
           --use-signing-config=false \
           --oidc-provider=github-actions \
           --oidc-issuer=https://token.actions.githubusercontent.com \
-          ${{ steps.vars.outputs.image }}
+          ${{ steps.vars.outputs.registry }}/${{ inputs.repository }}@${{ steps.digest.outputs.digest }}
 
     - name: 🔓 Attest index SBOM
       shell: bash

--- a/.github/workflows/shell-release.yaml
+++ b/.github/workflows/shell-release.yaml
@@ -30,4 +30,5 @@ jobs:
       config-dir: images/shell
       tag: ${{ github.ref_name }}${{ matrix.variant == 'dev' && '-dev' || '' }}
       target: ${{ matrix.variant }}
+      vex-file: vex/shell.openvex.json
     secrets: inherit

--- a/.github/workflows/shell.yaml
+++ b/.github/workflows/shell.yaml
@@ -42,4 +42,5 @@ jobs:
       config-dir: images/shell
       tag: ${{ matrix.version }}${{ matrix.variant == 'dev' && '-dev' || '' }}
       target: ${{ matrix.variant }}
+      vex-file: vex/shell.openvex.json
     secrets: inherit

--- a/.github/workflows/vex-validate.yaml
+++ b/.github/workflows/vex-validate.yaml
@@ -39,13 +39,23 @@ jobs:
         chmod +x hack/scripts/validate-vex.sh
         hack/scripts/validate-vex.sh
 
-    - name: ✅ Run vexctl validate (spec-level check)
+    - name: ✅ Run vexctl spec-level check (per file)
       shell: bash
       run: |
+        shopt -s nullglob
+        vex_files=(vex/*.openvex.json)
+        shopt -u nullglob
+        if [ "${#vex_files[@]}" -eq 0 ]; then
+          echo "No VEX files found — skipping spec check."
+          exit 0
+        fi
         errors=0
-        for f in vex/*.openvex.json; do
-          echo "Validating ${f} with vexctl..."
-          if ! vexctl validate "${f}"; then
+        for f in "${vex_files[@]}"; do
+          echo "Checking ${f} with vexctl..."
+          if ! vexctl merge \
+              --id "https://atoma/vex/validate" \
+              --author "local" \
+              "${f}" > /dev/null; then
             echo "FAIL: vexctl rejected ${f}"
             errors=$((errors + 1))
           else
@@ -54,21 +64,11 @@ jobs:
         done
         if [ "$errors" -gt 0 ]; then
           echo ""
-          echo "${errors} file(s) failed vexctl validation."
+          echo "${errors} file(s) failed vexctl spec check."
           exit 1
         fi
         echo ""
-        echo "All VEX files passed vexctl validation."
-
-  merge-dry-run:
-    name: Merge VEX documents (dry run)
-    runs-on: ubuntu-latest
-    steps:
-    - name: 🚚 Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-    - name: 🎉 Setup vexctl
-      uses: openvex/setup-vexctl@v0.1.0
+        echo "All VEX files passed vexctl spec check."
 
     - name: 🔀 Merge all VEX documents (dry run)
       shell: bash

--- a/.github/workflows/vex-validate.yaml
+++ b/.github/workflows/vex-validate.yaml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: VEX / Validate
+
+on: # yamllint disable-line rule:truthy
+  pull_request:
+    paths:
+    - "vex/**"
+    - .github/workflows/vex-validate.yaml
+    - hack/scripts/validate-vex.sh
+  push:
+    branches:
+    - main
+    paths:
+    - "vex/**"
+    - .github/workflows/vex-validate.yaml
+    - hack/scripts/validate-vex.sh
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate OpenVEX documents
+    runs-on: ubuntu-latest
+    steps:
+    - name: 🚚 Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    - name: 🎉 Setup vexctl
+      uses: openvex/setup-vexctl@v0.1.0
+
+    - name: 🔧 Run local schema validation
+      shell: bash
+      run: |
+        chmod +x hack/scripts/validate-vex.sh
+        hack/scripts/validate-vex.sh
+
+    - name: ✅ Run vexctl validate (spec-level check)
+      shell: bash
+      run: |
+        errors=0
+        for f in vex/*.openvex.json; do
+          echo "Validating ${f} with vexctl..."
+          if ! vexctl validate "${f}"; then
+            echo "FAIL: vexctl rejected ${f}"
+            errors=$((errors + 1))
+          else
+            echo "OK:   ${f}"
+          fi
+        done
+        if [ "$errors" -gt 0 ]; then
+          echo ""
+          echo "${errors} file(s) failed vexctl validation."
+          exit 1
+        fi
+        echo ""
+        echo "All VEX files passed vexctl validation."
+
+  merge-dry-run:
+    name: Merge VEX documents (dry run)
+    runs-on: ubuntu-latest
+    steps:
+    - name: 🚚 Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    - name: 🎉 Setup vexctl
+      uses: openvex/setup-vexctl@v0.1.0
+
+    - name: 🔀 Merge all VEX documents (dry run)
+      shell: bash
+      run: |
+        shopt -s nullglob
+        vex_files=(vex/*.openvex.json)
+        shopt -u nullglob
+        if [ "${#vex_files[@]}" -eq 0 ]; then
+          echo "No VEX files found — nothing to merge."
+          exit 0
+        fi
+        echo "Merging ${#vex_files[@]} VEX file(s): ${vex_files[*]}"
+        vexctl merge "${vex_files[@]}" | tee merged.openvex.json
+        echo ""
+        echo "Merge succeeded. Statement count in merged doc:"
+        jq '.statements | length' merged.openvex.json

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ sbom: guard-IMAGE ## Generate SBOM for container image
 		echo -e "$(ERROR_COLOR)Image tar file not found. Run 'make build-image IMAGE=$(IMAGE)' first$(NO_COLOR)"; \
 	fi
 
-.PHONY: validate-vex
-validate-vex: ## Validate all VEX documents
+.PHONY: vex
+vex: ## Validate all VEX documents
 	@echo -e "$(OK_COLOR)[$(APP)] Validate VEX documents$(NO_COLOR)"
 	@bash hack/scripts/validate-vex.sh

--- a/Makefile
+++ b/Makefile
@@ -130,3 +130,8 @@ sbom: guard-IMAGE ## Generate SBOM for container image
 	else \
 		echo -e "$(ERROR_COLOR)Image tar file not found. Run 'make build-image IMAGE=$(IMAGE)' first$(NO_COLOR)"; \
 	fi
+
+.PHONY: validate-vex
+validate-vex: ## Validate all VEX documents
+	@echo -e "$(OK_COLOR)[$(APP)] Validate VEX documents$(NO_COLOR)"
+	@bash hack/scripts/validate-vex.sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,6 +16,12 @@
     Advisory Database and open PRs with patches
 - The [Scorecard GitHub Action](https://github.com/ossf/scorecard-action)
   automates the process by running security checks on the GitHub repository.
+- [VEX (Vulnerability Exploitability eXchange)](https://openvex.dev/) statements
+  in `vex/` are applied to all container image scans via
+  [vexctl](https://github.com/openvex/vexctl). Scanner findings for CVEs that are
+  demonstrably not exploitable in our images are suppressed before results are
+  uploaded to GitHub Security. See [`vex/README.md`](vex/README.md) for the
+  criteria and process for adding new statements.
 
 ## Supported Versions
 

--- a/hack/scripts/validate-vex.sh
+++ b/hack/scripts/validate-vex.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Validate every vex/<image>.openvex.json doc against the OpenVEX v0.2.0 shape
+# we use in this repo. Hand-rolled checks (jq, no extra runtime deps).
+#
+# Exits non-zero on the first malformed file so CI fails loudly.
+#
+# Usage:
+#   hack/scripts/validate-vex.sh                  # validate every vex/*.openvex.json
+#   hack/scripts/validate-vex.sh vex/shell.openvex.json [...]   # specific files
+
+set -euo pipefail
+
+if [ "$#" -gt 0 ]; then
+  files=("$@")
+else
+  shopt -s nullglob
+  files=(vex/*.openvex.json)
+  shopt -u nullglob
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "no VEX files to validate" >&2
+  exit 1
+fi
+
+errors=0
+for f in "${files[@]}"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL $f: file not found" >&2
+    errors=$((errors + 1))
+    continue
+  fi
+
+  if ! jq -e . "$f" >/dev/null 2>&1; then
+    echo "FAIL $f: invalid JSON" >&2
+    errors=$((errors + 1))
+    continue
+  fi
+
+  # Required top-level fields.
+  for key in '@context' '@id' author timestamp version statements; do
+    if ! jq -e --arg k "$key" 'has($k)' "$f" >/dev/null; then
+      echo "FAIL $f: missing required field '$key'" >&2
+      errors=$((errors + 1))
+      continue 2
+    fi
+  done
+
+  # @context must be an OpenVEX context URI.
+  ctx=$(jq -r '."@context"' "$f")
+  case "$ctx" in
+    https://openvex.dev/ns/v0.2.0|https://openvex.dev/ns) ;;
+    *) echo "FAIL $f: unexpected @context '$ctx'" >&2; errors=$((errors + 1)); continue ;;
+  esac
+
+  # version must be a positive integer.
+  if ! jq -e '.version | type == "number" and . >= 1 and floor == .' "$f" >/dev/null; then
+    echo "FAIL $f: 'version' must be a positive integer" >&2
+    errors=$((errors + 1))
+    continue
+  fi
+
+  # statements must be an array.
+  if ! jq -e '.statements | type == "array"' "$f" >/dev/null; then
+    echo "FAIL $f: 'statements' must be an array" >&2
+    errors=$((errors + 1))
+    continue
+  fi
+
+  # If any statements exist, each needs vulnerability.name, products[], status.
+  stmt_count=$(jq '.statements | length' "$f")
+  if [ "$stmt_count" -gt 0 ]; then
+    bad=$(jq -r '
+      [ .statements[]
+        | select(
+            (has("vulnerability") | not)
+            or (.vulnerability | has("name") | not)
+            or (has("products") | not)
+            or (.products | type != "array")
+            or (.products | length == 0)
+            or (has("status") | not)
+            or ((.status | IN("not_affected","affected","fixed","under_investigation")) | not)
+            or (.status == "not_affected" and (has("justification") | not))
+          )
+        | .vulnerability.name // "<unknown>"
+      ] | join(",")
+    ' "$f")
+    if [ -n "$bad" ]; then
+      echo "FAIL $f: malformed statements for: $bad" >&2
+      errors=$((errors + 1))
+      continue
+    fi
+  fi
+
+  echo "ok   $f ($stmt_count statement(s))"
+done
+
+if [ "$errors" -gt 0 ]; then
+  echo "" >&2
+  echo "$errors file(s) failed validation" >&2
+  exit 1
+fi
+
+echo ""
+echo "All ${#files[@]} VEX file(s) valid."

--- a/vex/README.md
+++ b/vex/README.md
@@ -1,0 +1,92 @@
+# VEX — Vulnerability Exploitability eXchange
+
+This directory contains OpenVEX documents for the atoma project. Each file
+`vex/<image>.openvex.json` contains author-asserted statements about CVEs
+that are not exploitable in our container images.
+
+## What is VEX?
+
+When a vulnerability scanner (grype, trivy, snyk) finds a CVE in our image, it's
+reporting that a vulnerable *package* is present — not that the vulnerable
+*code path* is reachable. VEX (Vulnerability Exploitability eXchange) is the
+standardized way to tell a scanner "we know about CVE-X and it does **not**
+affect this image, because we don't compile that subsystem / don't expose that
+endpoint / patched it ourselves / etc."
+
+We use [OpenVEX v0.2.0](https://openvex.dev/) — the format SPDX, CycloneDX, and
+grype all consume natively.
+
+## When to add a statement
+
+Only when **all four** are true:
+
+1. Grype (or another scanner) reports a CVE against one of our images.
+2. We have a defensible reason the CVE is not exploitable here.
+3. The reason is durable (not "we'll fix it next week" — use a fix PR for that).
+4. We can write the justification in one sentence a stranger would believe.
+
+If we can't meet #4, don't write the statement. An unbacked `not_affected` is
+worse than no statement at all.
+
+## How to add a statement
+
+1. Identify the image and the CVE: e.g. infra-tools, CVE-2024-12345.
+2. Open `vex/infra-tools.openvex.json`.
+3. Append to `statements[]`:
+
+```json
+{
+  "vulnerability": { "name": "CVE-2024-12345" },
+  "products": [
+    { "@id": "pkg:oci/atoma-infra-tools?repository_url=ghcr.io/nicolaslamirault" }
+  ],
+  "status": "not_affected",
+  "justification": "vulnerable_code_not_in_execute_path",
+  "impact_statement": "The bug is in nginx's mail proxy module; we build with --without-mail_pop3_module --without-mail_imap_module --without-mail_smtp_module."
+}
+```
+
+4. Bump the document's top-level `version` integer (start at 1, increment on
+every edit — readers use this to detect changes).
+5. Update the top-level `timestamp` to today (`date -u +%Y-%m-%dT%H:%M:%SZ`).
+6. Run `hack/scripts/validate-vex.sh vex/infra-tools.openvex.json` locally to confirm shape.
+7. Commit on a branch named `vex/<image>-<cve>`, open a PR.
+
+## Valid `status` values
+
+| Status | Meaning |
+| --- | --- |
+| `not_affected` | The CVE exists in the package but cannot affect this image. **Requires** `justification`. |
+| `affected` | The CVE affects this image and we have not patched it. Should be rare — usually we'd ship a fix. |
+| `fixed` | We backported a patch (in `melange.yaml`) and the vulnerable code is no longer present. |
+| `under_investigation` | We're still triaging. Time-bound — don't leave a CVE in this state for weeks. |
+
+## Standard `justification` values for `not_affected`
+
+These are the OpenVEX-standardized strings — use them verbatim:
+
+- `component_not_present` — the vulnerable component isn't in our image at all
+- `vulnerable_code_not_present` — the package is present but our build excluded the vulnerable code
+- `vulnerable_code_not_in_execute_path` — the code is present but unreachable in normal operation
+- `vulnerable_code_cannot_be_controlled_by_adversary` — reachable but only via a trusted path
+- `inline_mitigations_already_exist` — a runtime mitigation (e.g. seccomp, AppArmor) blocks exploitation
+
+The free-form `impact_statement` field is where you explain *which* of these
+applies and how, in one or two sentences.
+
+## Validating locally
+
+```bash
+# all images
+hack/scripts/validate-vex.sh
+
+# specific file
+hack/scripts/validate-vex.sh vex/infra-tools.openvex.json
+```
+
+## Current VEX files
+
+| Image | File | Status |
+| --- | --- | --- |
+| infra-tools | [vex/infra-tools.openvex.json](./infra-tools.openvex.json) | Skeleton |
+| shell | [vex/shell.openvex.json](./shell.openvex.json) | Skeleton |

--- a/vex/infra-tools.openvex.json
+++ b/vex/infra-tools.openvex.json
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://github.com/nicolaslamirault/atoma/vex/infra-tools",
-  "author": "nicolaslamirault",
+  "author": "nlamirault",
   "timestamp": "2026-06-24T00:00:00Z",
   "version": 1,
   "tooling": "hack/scripts/validate-vex.sh",

--- a/vex/infra-tools.openvex.json
+++ b/vex/infra-tools.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/nicolaslamirault/atoma/vex/infra-tools",
+  "author": "nicolaslamirault",
+  "timestamp": "2026-06-24T00:00:00Z",
+  "version": 1,
+  "tooling": "hack/scripts/validate-vex.sh",
+  "statements": []
+}

--- a/vex/shell.openvex.json
+++ b/vex/shell.openvex.json
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://github.com/nicolaslamirault/atoma/vex/shell",
-  "author": "nicolaslamirault",
+  "author": "nlamirault",
   "timestamp": "2026-06-24T00:00:00Z",
   "version": 1,
   "tooling": "hack/scripts/validate-vex.sh",

--- a/vex/shell.openvex.json
+++ b/vex/shell.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/nicolaslamirault/atoma/vex/shell",
+  "author": "nicolaslamirault",
+  "timestamp": "2026-06-24T00:00:00Z",
+  "version": 1,
+  "tooling": "hack/scripts/validate-vex.sh",
+  "statements": []
+}


### PR DESCRIPTION
## Summary

- Integrate `vexctl` into the container image release workflow to merge VEX documents and filter SARIF results before uploading to GitHub Security
- Add a `vex-file` input parameter to the reusable release workflow so image-specific VEX documents can be passed per caller
- Add a new `vex-validate.yaml` CI workflow to validate and dry-run merge all OpenVEX documents on PRs touching `vex/`
- Wire `vex-file` parameter in `infra-tools` and `shell` image workflows
- Document the VEX process in `SECURITY.md` and rename the `validate-vex` Makefile target to `vex`