### PR TITLE
fix(github-actions): correct SHA

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@cb2c11159fc2a8d6411099ac565e2586b76f6204 # v2.10.4
+      uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
       with:
         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
@@ -43,13 +43,13 @@ jobs:
         publish_results: true
 
     - name: Upload artifact
-      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd1954910f0fb270230 # v4.6.0
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: SARIF file
         path: results.sarif
         retention-days: 5
 
     - name: Upload SARIF results
-      uses: github/codeql-action/upload-sarif@b56ba49b26b50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
+      uses: github/codeql-action/upload-sarif@a65a038433a26f4363cf9f029e3b9ceac831ad5d # v3.28.10
       with:
         sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Fix broken `scorecard` job ([run #28507429821](https://github.com/nlamirault/atoma/actions/runs/28507429821)) caused by three stale SHA pins in `.github/workflows/ossf-scorecard.yml`
- Upstream tags were force-pushed, making old commit SHAs unresolvable by GitHub Actions

## Changes

| Action | Old SHA | New SHA | Version |
|--------|---------|---------|---------|
| `step-security/harden-runner` | `cb2c11159...6204` | `cb605e52c...84e` | v2.10.4 |
| `actions/upload-artifact` | `65c4c4a1...0230` | `65c4c4a1...cf08` | v4.6.0 |
| `github/codeql-action/upload-sarif` | `b56ba49b...80d` | `a65a0384...ad5d` | v3.28.10 |

`actions/checkout@v4.2.2` SHA was already correct — no change needed.