### PR TITLE
fix(github-actions): Correct Upload Sarif SHA

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -50,6 +50,6 @@ jobs:
         retention-days: 5
 
     - name: Upload SARIF results
-      uses: github/codeql-action/upload-sarif@a65a038433a26f4363cf9f029e3b9ceac831ad5d # v3.28.10
+      uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
       with:
         sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Pin `github/codeql-action/upload-sarif` to `v3.36.2` (`dd903d2e4f5405488e5ef1422510ee31c8b32357`)

## Problem

The OSSF Scorecard action (`publish_results: true`) verifies that pinned action SHAs belong to the declared repository. The previous SHA (`a65a038433a26f4363cf9f029e3b9ceac831ad5d`, tagged `v3.28.10`) was rejected by the Scorecard backend with:

```
workflow verification failed: imposter commit: a65a038433a26f4363cf9f029e3b9ceac831ad5d
does not belong to github/codeql-action/upload-sarif
```

This caused the `scorecard` job to fail with HTTP 400 when publishing results.

## Fix

Updated the pinned SHA to the current `v3.36.2` release commit, which the Scorecard backend recognizes as a valid commit for `github/codeql-action/upload-sarif`.