### PR TITLE
security(github-actions): apply least-privilege permissions to release workflows

### DIFF
--- a/.github/workflows/infra-tools-release.yaml
+++ b/.github/workflows/infra-tools-release.yaml
@@ -10,19 +10,23 @@ on: # yamllint disable-line rule:truthy
     - published
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
-  attestations: write
-  id-token: write
-  security-events: write
-  actions: read
+# Declare default permissions as read only.
+permissions: read-all
 
 jobs:
   publish:
+    permissions:
+      actions: read
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+      security-events: write
+
     strategy:
       matrix:
         variant: [prod, shell, dev]
+
     name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
     uses: "./.github/workflows/release.yaml"
     with:

--- a/.github/workflows/infra-tools.yaml
+++ b/.github/workflows/infra-tools.yaml
@@ -21,20 +21,24 @@ on: # yamllint disable-line rule:truthy
     - "images/infra-tools/**/*.yaml"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
-  attestations: write
-  id-token: write
-  security-events: write
-  actions: read
+# Declare default permissions as read only.
+permissions: read-all
 
 jobs:
   publish:
+    permissions:
+      actions: read
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+      security-events: write
+
     strategy:
       matrix:
         version: [latest]
         variant: [prod, shell, dev]
+
     name: ${{ matrix.version }}${{ matrix.variant == 'shell' && '-shell' || matrix.variant == 'dev' && '-dev' || '' }}
     uses: "./.github/workflows/release.yaml"
     with:

--- a/.github/workflows/shell-release.yaml
+++ b/.github/workflows/shell-release.yaml
@@ -10,19 +10,23 @@ on: # yamllint disable-line rule:truthy
     - published
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
-  attestations: write
-  id-token: write
-  security-events: write
-  actions: read
+# Declare default permissions as read only.
+permissions: read-all
 
 jobs:
   publish:
+    permissions:
+      actions: read
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+      security-events: write
+
     strategy:
       matrix:
         variant: [prod, dev]
+
     name: ${{ matrix.version }}${{ matrix.variant == 'dev' && '-dev' || '' }}
     uses: "./.github/workflows/release.yaml"
     with:

--- a/.github/workflows/shell.yaml
+++ b/.github/workflows/shell.yaml
@@ -21,20 +21,24 @@ on: # yamllint disable-line rule:truthy
     - "images/shell/**/*.yaml"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
-  attestations: write
-  id-token: write
-  security-events: write
-  actions: read
+# Declare default permissions as read only.
+permissions: read-all
 
 jobs:
   publish:
+    permissions:
+      actions: read
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+      security-events: write
+
     strategy:
       matrix:
         version: [latest]
         variant: [prod, dev]
+
     name: ${{ matrix.version }}${{ matrix.variant == 'dev' && '-dev' || '' }}
     uses: "./.github/workflows/release.yaml"
     with:


### PR DESCRIPTION
## Summary

- Set `permissions: read-all` as default at workflow level for all release workflows
- Move explicit permission grants to job-level to follow least-privilege principle
- Fix duplicate `permissions` block and YAML corruption in `shell.yaml`

Closes #77 